### PR TITLE
Modify activation to be in non-silent mode so we can use the activation hook.

### DIFF
--- a/src/Installer/Handler/Plugin.php
+++ b/src/Installer/Handler/Plugin.php
@@ -134,7 +134,7 @@ class Plugin implements Handler {
 			return true;
 		}
 
-		$activate = activate_plugin( $this->get_basename(), '', false, true );
+		$activate = activate_plugin( $this->get_basename() );
 
 		$this->is_active = ( $activate === null );
 
@@ -420,7 +420,7 @@ class Plugin implements Handler {
 			$installed = $upgrader->install( $url );
 
 			if ( $installed ) {
-				$activate = activate_plugin( $this->get_basename(), '', false, true );
+				$activate = activate_plugin( $this->get_basename() );
 				$success  = ! is_wp_error( $activate );
 			} else {
 				$success = false;


### PR DESCRIPTION
Removing the silent mode for the plugin activation to be able to use the activation hooks.

More context:

If it's in silent mode, the activation hook is not executing. Hence we'll have a different behavior if the plugin is activated from the `Plugins` screen or from the notice.

https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-includes/plugin.php#L868-L871

https://github.com/WordPress/wordpress-develop/blob/6.1/src/wp-admin/includes/plugin.php#L629-L730


https://user-images.githubusercontent.com/252415/219744168-7ec79ee8-7b9a-4e57-af33-e5eb4ccd94ac.mov



