### PR TITLE
Fix PHP 8.1 deprecation warnings.

### DIFF
--- a/src/Installer/Handler/Plugin.php
+++ b/src/Installer/Handler/Plugin.php
@@ -114,7 +114,7 @@ class Plugin implements Handler {
 	 *
 	 * @since 1.0.0
 	 */
-	public function __construct( string $name, string $slug, ?string $download_url = null, ?string $did_action = null, string $js_action ) {
+	public function __construct( string $name, string $slug, ?string $download_url = null, ?string $did_action = null, ?string $js_action = null ) {
 		$this->name         = $name;
 		$this->slug         = $slug;
 		$this->download_url = $download_url;


### PR DESCRIPTION
Ticket : [TEC-4809](https://theeventscalendar.atlassian.net/browse/TEC-4809)

This is a tentative fix because I'm lacking a bit of context. @borkweb I believe you're the best person to review this.

I'm declaring `$js_action` as an optional param and assigning an initial value of null. If I declare the variable as a required param without assigning an initial value, I get a fatal error indicating that the initial value being passed is null and not a string.

**Screenshot 📸**

![image](https://github.com/stellarwp/installer/assets/22029087/ad09f973-3653-482b-9d01-6e33d67bcc23)


[TEC-4809]: https://theeventscalendar.atlassian.net/browse/TEC-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ